### PR TITLE
fixes syntax error on server_name

### DIFF
--- a/templates/etc/nginx/sites-available/status.j2
+++ b/templates/etc/nginx/sites-available/status.j2
@@ -3,7 +3,7 @@
 
 server {
   listen {{ NGINX_CONFIG.status_page.bind }}:{{ NGINX_CONFIG.status_page.port }};
-  server_name {{ NGINX_CONFIG.status_page.bind }} localhost
+  server_name {{ NGINX_CONFIG.status_page.bind }} localhost;
 
   # log config
 {% if NGINX_CONFIG.log.syslog and NGINX_CONFIG.log.syslog_host is not none %}


### PR DESCRIPTION
There is a missing semi colon in template.

Tested locally.